### PR TITLE
Removing implementation that does not comply with link headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -677,7 +677,6 @@ left:4.5em;
                                 <li><a href="https://dokie.li/">dokieli</a> (sender, consumer)</li>
                                 <li><a href="https://github.com/solid/solid-inbox">solid-inbox</a> (consumer)</li>
                                 <li><a href="https://github.com/solid/solid-client">solid-client</a> (sender)</li>
-                                <li><a href="https://github.com/melvincarvalho/vocab">solid words</a> (sender)</li>
                             </ul>
                         </div>
                     </section>


### PR DESCRIPTION
I would love to support LDN with an implementation but this implementation does not support follow your nose via link headers, and is not likely to in the near future.
