### PR TITLE
Fix typo s/complimentary/complementary

### DIFF
--- a/index.html
+++ b/index.html
@@ -219,7 +219,7 @@ left:4.5em;
               <section id="social-web-working-group" inlist="" rel="schema:hasPart" resource="#social-web-working-group">
                 <h3 property="schema:name">Social Web Working Group</h3>
                 <div datatype="rdf:HTML" property="schema:description">
-                  <p><a href="#ldn"><abbr title="Linked Data Notifications">LDN</abbr></a> is one of several related specifications being produced by the Social Web Working Group. Implementers interested in alternative approaches and complimentary protocols should start by reading the overview document <a class="bibref" href="#bib-social-web-protocols">Social Web Protocols</a>. Specific subsections of Social Web Protocols are referenced throughout this specification to highlight points of extensibility or interoperability with other protocols.</p>
+                  <p><a href="#ldn"><abbr title="Linked Data Notifications">LDN</abbr></a> is one of several related specifications being produced by the Social Web Working Group. Implementers interested in alternative approaches and complementary protocols should start by reading the overview document <a class="bibref" href="#bib-social-web-protocols">Social Web Protocols</a>. Specific subsections of Social Web Protocols are referenced throughout this specification to highlight points of extensibility or interoperability with other protocols.</p>
                 </div>
               </section>
 


### PR DESCRIPTION
This is a [correction class 2](https://www.w3.org/policies/process/#class-2) change.

Typo mentioned in https://github.com/w3c/ldn/issues/67#issue-596986954

